### PR TITLE
Remap scan topic to rgbd_scan for slam_toolbox node

### DIFF
--- a/pal_navigation_cfg_ari/launch/mapping_slam_toolbox.launch
+++ b/pal_navigation_cfg_ari/launch/mapping_slam_toolbox.launch
@@ -2,6 +2,8 @@
 <launch>
   <arg name="scan" default="rgbd_scan"/>
   <arg name="laser_model" default="rgbd_scan"/>
-  <include file="$(find slam_toolbox)/online_sync.launch"/>
   <rosparam file="$(find pal_navigation_cfg_ari)/config/mapping/slam_toolbox.yaml" command="load"/>
+  <node pkg="slam_toolbox" type="sync_slam_toolbox_node" name="slam_toolbox" output="screen">
+    <remap from="/scan" to="/$(arg scan)"/>
+  </node>
 </launch>


### PR DESCRIPTION
This PR remaps the `scan` topic to `rgbd_scan` for the `sync_slam_toolbox_node` node to it gets correctly connected to the laser scan.

If you run this command you should see the map being created in RViz:

```
roslaunch ari_2dnav_gazebo ari_mapping.launch public_sim:=true
```